### PR TITLE
Admin can add final remark at any time

### DIFF
--- a/app/templates/solution_group_page.html
+++ b/app/templates/solution_group_page.html
@@ -33,7 +33,7 @@
 
 <hr>
 
-{% if solution_group.remarks | length > 2 %}
+{% if solution_group.remarks | length > 2 or current_user.has_role('Admin') %}
   <div class="container-fluid">
     {% if solution_group.final_remark is none %}
       <h3>Add final remark:</h3>


### PR DESCRIPTION
Up to now, a final remark form would appear only if there were at least 3 regular remarks, which can become cumbersome
in clear cases and would lead to the final reviewer simply copying a remark until they hit 3 remarks. The condition for
showing the final remark form was expanded to give access to anyone with an Admin role immediately.