### PR TITLE
Made remark forms larger and resizable

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -1,6 +1,7 @@
 from flask_wtf import FlaskForm
 from wtforms import TextAreaField, DecimalField, SubmitField
 from wtforms.validators import InputRequired, NumberRange
+from wtforms.widgets import TextArea
 
 
 class RemarkForm(FlaskForm):
@@ -9,7 +10,7 @@ class RemarkForm(FlaskForm):
     The author, date and solution group do not have their fields because they can be inferred from the context.
     """
 
-    remark_text = TextAreaField(label="Remark text", validators=[])
+    remark_text = TextAreaField(label="Remark text", validators=[], widget=TextArea())
     remark_score_percentage = DecimalField(label="Score percentage",
                                            validators=[InputRequired(), NumberRange(min=0, max=1.5)])
     submit_remark = SubmitField("Submit remark")
@@ -21,7 +22,7 @@ class FinalRemarkForm(FlaskForm):
     caused problems with passing data. It should be looked into in the future.
     """
 
-    remark_text = TextAreaField(label="Final remark text", validators=[InputRequired()])
+    remark_text = TextAreaField(label="Final remark text", validators=[InputRequired()], widget=TextArea())
     remark_score_percentage = DecimalField(label="Score percentage",
                                            validators=[InputRequired(), NumberRange(min=0, max=1.5)])
     submit_final_remark = SubmitField("Submit final remark")

--- a/app/templates/solution_group_page.html
+++ b/app/templates/solution_group_page.html
@@ -33,6 +33,20 @@
 
 <hr>
 
+<div class="container-fluid">
+  <h3>Remarks:</h3>
+  <ul class="list-group">
+    {% for remark in solution_group.remarks %}
+      <li class="list-group-item">
+        {{ remark.text }} <br>
+        Score percentage: {{ remark.score_percentage }} <br>
+        Author: {{ remark.author.username }}
+      </li>
+      <hr>
+    {% endfor %}
+  </ul>
+</div>
+
 {% if solution_group.remarks | length > 2 or current_user.has_role('Admin') %}
   <div class="container-fluid">
     {% if solution_group.final_remark is none %}
@@ -43,7 +57,8 @@
     <form action="" method="post">
       {{ final_remark_form.hidden_tag() }}
       <p>
-        {{ final_remark_form.remark_text.label.text }}: {{ final_remark_form.remark_text() }}
+        {{ final_remark_form.remark_text.label.text }}:<br>
+        {{ final_remark_form.remark_text(cols="100", rows="5") }}
         {% for error in final_remark_form.remark_text.errors %}
           <span class="error">{{ error }}</span>
         {% endfor %}
@@ -67,7 +82,8 @@
   <form action="" method="post">
     {{ remark_form.hidden_tag() }}
     <p>
-      {{ remark_form.remark_text.label.text }}: {{ remark_form.remark_text() }}
+      {{ remark_form.remark_text.label.text }}:<br>
+      {{ remark_form.remark_text(cols="100", rows="5") }}
       {% for error in remark_form.remark_text.errors %}
         <span class="error">{{ error }}</span>
       {% endfor %}
@@ -83,17 +99,4 @@
 </div>
 
 
-<div class="container-fluid">
-  <h3>Remarks:</h3>
-  <ul class="list-group">
-    {% for remark in solution_group.remarks %}
-      <li class="list-group-item">
-        {{ remark.text }} <br>
-        Score percentage: {{ remark.score_percentage }} <br>
-        Author: {{ remark.author.username }}
-      </li>
-      <hr>
-    {% endfor %}
-  </ul>
-</div>
 {% endblock %}


### PR DESCRIPTION
Remark forms' text areas are now backed by WTForms's TextArea widget, which can handle size specification and resizing.