### PR TITLE
Fixed pinned items unlimited max-height issue

### DIFF
--- a/app/static/css/okosl.css
+++ b/app/static/css/okosl.css
@@ -40,3 +40,8 @@ textarea { font-family: "Courier New", Courier, monospace; }
 	padding: 20px 20px 0;
 	z-index: 1;
 }
+
+.list-item-fixed .list-group {
+	overflow-x: scroll;
+	max-height: 150px;
+}


### PR DESCRIPTION
Ispravak CSS-a kako bi se spriječilo da pinned items zauzmu cijeli screen kod prevelikog heighta